### PR TITLE
Experimental html5 support

### DIFF
--- a/samples/basic/source/PlayState.hx
+++ b/samples/basic/source/PlayState.hx
@@ -22,6 +22,10 @@ class PlayState extends FlxState
 		FlxG.sound.playMusic("assets/beeper.ogg");
 		FlxG.sound.music.stop();
 		FlxG.sound.music.looped = true;
+
+		// NOTE: Due to a limitation, on HTML5
+		// you have to play the audio source
+		// before trying to make a waveform from it.
 		FlxG.sound.music.play(true);
 
 		// Check if bitmap max texture size is available.

--- a/samples/basic/source/PlayState.hx
+++ b/samples/basic/source/PlayState.hx
@@ -22,6 +22,7 @@ class PlayState extends FlxState
 		FlxG.sound.playMusic("assets/beeper.ogg");
 		FlxG.sound.music.stop();
 		FlxG.sound.music.looped = true;
+		FlxG.sound.music.play(true);
 
 		// Check if bitmap max texture size is available.
 		if (FlxG.bitmap.maxTextureSize != -1)
@@ -49,8 +50,6 @@ class PlayState extends FlxState
 		// is true by default, and changing the waveform draw mode above will trigger a redraw.
 		// waveform.generateWaveformBitmap();
 		add(waveform);
-
-		FlxG.sound.music.play(true);
 	}
 
 	override public function update(elapsed:Float):Void

--- a/src/flixel/addons/display/waveform/BytesExt.hx
+++ b/src/flixel/addons/display/waveform/BytesExt.hx
@@ -44,7 +44,7 @@ class BytesExt
     /**
      * The minimum value of a signed 24bit integer.
      */
-     public static inline final INT24_MIN:Int = -8388608;
+    public static inline final INT24_MIN:Int = -8388608;
 
     /**
      * The maximum value of a signed 24bit integer.
@@ -103,7 +103,6 @@ class BytesExt
     public static inline function normalizeUInt8(bytes:Bytes, pos:Int):Float
     {
         // bytes.get() returns an unsigned int8?
-        // return bytes.get(pos) / UINT8_MAX;
         return FlxMath.remapToRange(bytes.get(pos), 0, UINT8_MAX, -1, 1);
     }
 
@@ -115,7 +114,6 @@ class BytesExt
      */
     public static inline function normalizeInt16(bytes:Bytes, pos:Int):Float
     {
-        // return getInt16(bytes, pos) / INT16_MAX;
         return FlxMath.remapToRange(getInt16(bytes, pos), INT16_MIN, INT16_MAX, -1, 1);
     }
 
@@ -127,7 +125,6 @@ class BytesExt
      */
     public static inline function normalizeInt24(bytes:Bytes, pos:Int):Float
     {
-        // return getInt24(bytes, pos) / INT24_MAX;
         return FlxMath.remapToRange(getInt24(bytes, pos), INT24_MIN, INT24_MAX, -1, 1);
     }
 
@@ -139,7 +136,6 @@ class BytesExt
      */
     public static inline function normalizeInt32(bytes:Bytes, pos:Int):Float
     {
-        // return bytes.getInt32(pos) / INT32_MAX;
         return FlxMath.remapToRange(bytes.getInt32(pos), INT32_MIN, INT32_MAX, -1, 1);
     }
 }

--- a/src/flixel/addons/display/waveform/BytesExt.hx
+++ b/src/flixel/addons/display/waveform/BytesExt.hx
@@ -1,6 +1,7 @@
 package flixel.addons.display.waveform;
 
 import haxe.io.Bytes;
+import flixel.math.FlxMath;
 
 /**
  * Helper class that adds additional functionality to
@@ -11,14 +12,24 @@ import haxe.io.Bytes;
 class BytesExt
 {
     /**
+     * The minimum value of a signed 8bit integer.
+     */
+    public static inline final INT8_MIN:Int = -127;
+
+    /**
      * The maximum value of a signed 8bit integer.
      */
-    public static inline final INT8_MAX:Int = 128;
+    public static inline final INT8_MAX:Int = 127;
 
     /**
      * The maximum value of an unsigned 8bit integer.
      */
     public static inline final UINT8_MAX:Int = 255;
+
+    /**
+     * The minimum value of a signed 16bit integer.
+     */
+    public static inline final INT16_MIN:Int = -32768;
 
     /**
      * The maximum value of a signed 16bit integer.
@@ -31,9 +42,19 @@ class BytesExt
     public static inline final UINT16_MAX:Int = 65535;
 
     /**
+     * The minimum value of a signed 24bit integer.
+     */
+     public static inline final INT24_MIN:Int = -8388608;
+
+    /**
      * The maximum value of a signed 24bit integer.
      */
     public static inline final INT24_MAX:Int = 8388607;
+
+    /**
+     * The minimum value of a signed 32bit integer.
+     */
+    public static inline final INT32_MIN:Int = -2147483648;
 
     /**
      * The maximum value of a signed 32bit integer.
@@ -74,7 +95,7 @@ class BytesExt
     }
 
     /**
-     * Reads & normalizes an unsigned 8bit integer in the range of 0 to 1.
+     * Reads & normalizes an unsigned 8bit integer in the range of -1 to 1.
      * @param bytes Bytes to read from
      * @param pos Position to read from
      * @return Normalized value
@@ -82,39 +103,43 @@ class BytesExt
     public static inline function normalizeUInt8(bytes:Bytes, pos:Int):Float
     {
         // bytes.get() returns an unsigned int8?
-        return bytes.get(pos) / UINT8_MAX;
+        // return bytes.get(pos) / UINT8_MAX;
+        return FlxMath.remapToRange(bytes.get(pos), 0, UINT8_MAX, -1, 1);
     }
 
     /**
-     * Reads & normalizes a signed 16bit integer in the range of 0 to 1.
+     * Reads & normalizes a signed 16bit integer in the range of -1 to 1.
      * @param bytes Bytes to read from
      * @param pos Position to read from
      * @return Normalized value
      */
     public static inline function normalizeInt16(bytes:Bytes, pos:Int):Float
     {
-        return getInt16(bytes, pos) / INT16_MAX;
+        // return getInt16(bytes, pos) / INT16_MAX;
+        return FlxMath.remapToRange(getInt16(bytes, pos), INT16_MIN, INT16_MAX, -1, 1);
     }
 
     /**
-     * Reads & normalizes a signed 24bit integer in the range of 0 to 1.
+     * Reads & normalizes a signed 24bit integer in the range of -1 to 1.
      * @param bytes Bytes to read from
      * @param pos Position to read from
      * @return Normalized value
      */
     public static inline function normalizeInt24(bytes:Bytes, pos:Int):Float
     {
-        return getInt24(bytes, pos) / INT24_MAX;
+        // return getInt24(bytes, pos) / INT24_MAX;
+        return FlxMath.remapToRange(getInt24(bytes, pos), INT24_MIN, INT24_MAX, -1, 1);
     }
 
     /**
-     * Reads & normalizes a signed 32bit integer in the range of 0 to 1.
+     * Reads & normalizes a signed 32bit integer in the range of -1 to 1.
      * @param bytes Bytes to read from
      * @param pos Position to read from
      * @return Normalized value
      */
     public static inline function normalizeInt32(bytes:Bytes, pos:Int):Float
     {
-        return bytes.getInt32(pos) / INT32_MAX;
+        // return bytes.getInt32(pos) / INT32_MAX;
+        return FlxMath.remapToRange(bytes.getInt32(pos), INT32_MIN, INT32_MAX, -1, 1);
     }
 }

--- a/src/flixel/addons/display/waveform/FlxWaveform.hx
+++ b/src/flixel/addons/display/waveform/FlxWaveform.hx
@@ -1,6 +1,10 @@
 
 package flixel.addons.display.waveform;
 
+import lime.utils.Int8Array;
+import lime.utils.ArrayBufferView;
+import lime.utils.ArrayBuffer;
+import lime.utils.UInt8Array;
 import haxe.io.Bytes;
 import lime.media.AudioBuffer;
 import openfl.geom.Rectangle;
@@ -229,6 +233,50 @@ class FlxWaveform extends FlxSprite
      */
     public function loadDataFromAudioBuffer(buffer:AudioBuffer):Void
     {
+        #if (js && html5 && lime_howlerjs)
+        // On HTML5 Lime does not expose any kind of AudioBuffer
+        // data which makes it difficult to do anything.
+        // Our only hope is to try to get it from howler.js
+
+        // TODO: This approach seems very unstable, as good as it gets right now?
+        // bufferSource seems to not be reliable and whether it's null depends on timing and similar.
+        
+        var n = buffer.src._sounds[0]._node;
+        trace(n);
+        js.html.Console.log(n);
+        var bufferSource:js.html.audio.AudioBufferSourceNode = buffer.src._sounds[0]._node.bufferSource;
+        trace(bufferSource);
+		if (bufferSource != null)
+		{
+            trace("We are so back");
+            var jsBuffer:js.html.audio.AudioBuffer = bufferSource.buffer;
+            // Data is always a Float32Array
+			buffer.bitsPerSample = 32;
+            buffer.channels = jsBuffer.numberOfChannels;
+            buffer.sampleRate = Std.int(jsBuffer.sampleRate);
+
+            var left = jsBuffer.getChannelData(0);
+            var right = null;
+            if (buffer.channels == 2)
+                right = jsBuffer.getChannelData(1);
+            var combined:js.lib.Float32Array;
+            
+            // convert into lime friendly format
+            // TODO: How does this affect memory?
+            combined = new js.lib.Float32Array(left.length * 2);
+            for (i in 0...left.length)
+            {
+                combined[i * 2] = left[i];
+                if (buffer.channels == 2)
+                    combined[i * 2 + 1] = right[i];
+            }
+
+            left = null;
+            right = null;
+            buffer.data = cast combined;
+		}
+        #end
+
         if (!bufferValid(buffer))
         {
             FlxG.log.error("[FlxWaveform] Tried to load invalid buffer! Make sure the audio buffer has valid sampleRate, bitsPerSample, channels and data.");
@@ -458,6 +506,8 @@ class FlxWaveform extends FlxSprite
         var right:Array<Float> = null;
         if (stereo)
             right = [];
+
+        trace(samples.length);
 
         // Int32 is 4 bytes, times 2 for both channels.
         var step:Int = stereo ? 8 : 4;

--- a/src/flixel/addons/display/waveform/FlxWaveform.hx
+++ b/src/flixel/addons/display/waveform/FlxWaveform.hx
@@ -241,15 +241,11 @@ class FlxWaveform extends FlxSprite
             // TODO: This approach seems very unstable, as good as it gets right now?
             // bufferSource seems to be available DURING sound playback.
             // Attempting to access it before playing a sound will not work.
-            var n = buffer.src._sounds[0]._node;
-            trace(n);
-            js.html.Console.log(n);
             var bufferSource:js.html.audio.AudioBufferSourceNode = buffer?.src?._sounds[0]?._node?.bufferSource;
-            trace(bufferSource);
             if (bufferSource != null)
             {
-                trace("We are so back");
                 var jsBuffer:js.html.audio.AudioBuffer = bufferSource.buffer;
+
                 // Data is always a Float32Array
                 buffer.bitsPerSample = 32;
                 buffer.channels = jsBuffer.numberOfChannels;
@@ -260,24 +256,22 @@ class FlxWaveform extends FlxSprite
                 if (buffer.channels == 2)
                     right = jsBuffer.getChannelData(1);
                 
-                js.html.Console.log(left);
-                js.html.Console.log(right);
-                
                 // convert into lime friendly format
                 // TODO: How does this affect memory?
-                var combined = new Float32Array(left.length * 2);
-                for (i in 0...left.length)
+                var combined:js.lib.Float32Array = null;
+                if (buffer.channels == 2)
                 {
-                    combined[i * 2] = left[i];
-                    if (buffer.channels == 2)
-                        combined[i * 2 + 1] = right[i];
+                    combined = new Float32Array(left.length * 2);
+                    for (i in 0...left.length)
+                    {
+                        combined[i * 2] = left[i];
+                        if (buffer.channels == 2)
+                            combined[i * 2 + 1] = right[i];
+                    }
                 }
 
-                // left = null;
-                // right = null;
-                // TODO: IF ONLY ONE CHANNEL DON'T COMBINE BUT RATHER JUST PASS 1 CHANNEL HERE!!!
-                buffer.channels = 1;
-                buffer.data = cast left; // TODO: remove this temporary, and combine !!! 
+                // TODO: is it safe to cast this?
+                buffer.data = buffer.channels == 2 ? cast combined : cast left;
             }
         }
         #end

--- a/src/flixel/addons/display/waveform/FlxWaveform.hx
+++ b/src/flixel/addons/display/waveform/FlxWaveform.hx
@@ -234,7 +234,7 @@ class FlxWaveform extends FlxSprite
         // On HTML5 Lime does not expose any kind of AudioBuffer
         // data which makes it difficult to do anything.
         // Our only hope is to try to get it from howler.js
-        
+
         @:privateAccess
         if (!bufferValid(buffer) && buffer.__srcHowl != null)
         {
@@ -508,10 +508,6 @@ class FlxWaveform extends FlxSprite
         var step:Int = stereo ? 8 : 4;
         for (i in 0...Std.int(samples.length / step))
         {
-            // left.push((samples.getFloat(i * step) + 1) / 2);
-            // if (stereo)
-            //     right.push((samples.getFloat(i * step + 4) + 1) / 2);
-
             left.push(samples.getFloat(i * step));
             if (stereo)
                 right.push(samples.getFloat(i * step + 4));
@@ -540,7 +536,6 @@ class FlxWaveform extends FlxSprite
         var step:Int = stereo ? 8 : 4;
         for (i in 0...Std.int(samples.length / step))
         {
-            // trace(samples.getFloat(i * step));
             left.push(samples.normalizeInt32(i * step));
             if (stereo)
                 right.push(samples.normalizeInt32(i * step + 4));

--- a/src/flixel/addons/display/waveform/FlxWaveform.hx
+++ b/src/flixel/addons/display/waveform/FlxWaveform.hx
@@ -239,7 +239,8 @@ class FlxWaveform extends FlxSprite
         if (!bufferValid(buffer) && buffer.__srcHowl != null)
         {
             // TODO: This approach seems very unstable, as good as it gets right now?
-            // bufferSource seems to not be reliable and whether it's null depends on timing and similar.
+            // bufferSource seems to be available DURING sound playback.
+            // Attempting to access it before playing a sound will not work.
             var n = buffer.src._sounds[0]._node;
             trace(n);
             js.html.Console.log(n);
@@ -496,10 +497,8 @@ class FlxWaveform extends FlxSprite
     }
 
     /**
-     * Processes a `Bytes` instance containing audio data in 
-     * a 32bit float format and returns 2 arrays
-     * containing normalized samples in the range from 0 to 1
-     * for both audio channels.
+     * Does nothing really, as Float32 data is already normalized.
+     * Just seperates both channels into different arrays.
      * @param samples The audio buffer bytes data containing audio samples.
      * @param stereo Whether the data should be treated as stereo (2 channels).
      * @return A `NormalizedSampleData` containing normalized samples for both channels.
@@ -530,7 +529,7 @@ class FlxWaveform extends FlxSprite
     /**
      * Processes a `Bytes` instance containing audio data in 
      * a signed 32bit integer format and returns 2 arrays
-     * containing normalized samples in the range from 0 to 1
+     * containing normalized samples in the range from -1 to 1
      * for both audio channels.
      * @param samples The audio buffer bytes data containing audio samples.
      * @param stereo Whether the data should be treated as stereo (2 channels).
@@ -559,7 +558,7 @@ class FlxWaveform extends FlxSprite
     /**
      * Processes a `Bytes` instance containing audio data in 
      * a signed 24bit integer format and returns 2 arrays
-     * containing normalized samples in the range from 0 to 1
+     * containing normalized samples in the range from -1 to 1
      * for both audio channels.
      * @param samples The audio buffer bytes data containing audio samples.
      * @param stereo Whether the data should be treated as stereo (2 channels).
@@ -587,7 +586,7 @@ class FlxWaveform extends FlxSprite
     /**
      * Processes a `Bytes` instance containing audio data in 
      * a signed 16bit integer format and returns 2 arrays
-     * containing normalized samples in the range from 0 to 1
+     * containing normalized samples in the range from -1 to 1
      * for both audio channels.
      * @param samples The audio buffer bytes data containing audio samples.
      * @param stereo Whether the data should be treated as stereo (2 channels).
@@ -615,7 +614,7 @@ class FlxWaveform extends FlxSprite
     /**
      * Processes a `Bytes` instance containing audio data in 
      * an unsigned 8bit integer format and returns 2 arrays
-     * containing normalized samples in the range from 0 to 1
+     * containing normalized samples in the range from -1 to 1
      * for both audio channels.
      * @param samples The audio buffer bytes data containing audio samples.
      * @param stereo Whether the data should be treated as stereo (2 channels).


### PR DESCRIPTION
Adds experimental HTML5 support. This method doesn't seem to be 100% reliable, but it's better than nothing.

The only limitation of this that I'm aware of is that sounds need to be played first before making a waveform, otherwise it's not possible to access their buffer.

Partially resolves #1 