### PR TITLE
[QOL] Add onDataLoad signal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,12 +3,12 @@
 		"export/**/*.*": true
 	},
 	"[haxe]": {
-		"editor.formatOnSave": true,
-		"editor.formatOnSaveMode":"modifications",
-		"editor.formatOnPaste": false,
-		"editor.codeActionsOnSave": {
-			"source.sortImports": "explicit"
-		}
+		// "editor.formatOnSave": true,
+		// "editor.formatOnSaveMode":"modifications",
+		// "editor.formatOnPaste": false,
+		// "editor.codeActionsOnSave": {
+		// 	"source.sortImports": "explicit"
+		// }
 	},
 	"haxe.enableExtendedIndentation": true,
 	"lime.projectFile": "samples/minimal/Project.xml"

--- a/src/flixel/addons/display/waveform/FlxWaveform.hx
+++ b/src/flixel/addons/display/waveform/FlxWaveform.hx
@@ -363,12 +363,22 @@ class FlxWaveform extends FlxSprite
     }
 
 	/**
-	 * Dispatches when data on loaded
-     * and removes all signals as soon as that happens
+	 * Dispatches when `waveformBuffer` is set and is not null.
+	 * 
+	 * Removes all added functions when dispatched
 	 * 
 	 * @since 2.2.0
 	 */
 	public var onWaveformBufferSet:FlxSignal = new FlxSignal();
+
+	/**
+	 * Dispatches when `waveformBuffer` is set and is null.
+	 * 
+	 * Removes all added functions when dispatched
+	 * 
+	 * @since 2.2.0
+	 */
+	public var onWaveformBufferSetNull:FlxSignal = new FlxSignal();
 
    /**
      * Loads the audio buffer data neccessary for processing the 
@@ -407,12 +417,23 @@ class FlxWaveform extends FlxSprite
 			if (onWaveformBufferSet == null)
             {
 				onWaveformBufferSet = new FlxSignal();
-                FlxG.log.add('[FlxWaveform] Re-initalized `onDataLoad`');
+                FlxG.log.add('[FlxWaveform] Re-initalized `onWaveformBufferSet`');
             }
             else
             {
 				onWaveformBufferSet.dispatch();
 				onWaveformBufferSet.removeAll();
+            }
+        else
+			if (onWaveformBufferSetNull == null)
+            {
+				onWaveformBufferSetNull = new FlxSignal();
+                FlxG.log.add('[FlxWaveform] Re-initalized `onWaveformBufferSetNull`');
+            }
+            else
+            {
+				onWaveformBufferSetNull.dispatch();
+				onWaveformBufferSetNull.removeAll();
             }
     }
 

--- a/src/flixel/addons/display/waveform/FlxWaveform.hx
+++ b/src/flixel/addons/display/waveform/FlxWaveform.hx
@@ -368,7 +368,7 @@ class FlxWaveform extends FlxSprite
 	 * 
 	 * @since 2.2.0
 	 */
-	public var onDataLoad:FlxSignal = new FlxSignal();
+	public var onWaveformBufferSet:FlxSignal = new FlxSignal();
 
    /**
      * Loads the audio buffer data neccessary for processing the 
@@ -404,15 +404,15 @@ class FlxWaveform extends FlxSprite
         _drawDataDirty = true;
 
         if (waveformBuffer != null)
-            if (onDataLoad == null)
+			if (onWaveformBufferSet == null)
             {
-                onDataLoad = new FlxSignal();
+				onWaveformBufferSet = new FlxSignal();
                 FlxG.log.add('[FlxWaveform] Re-initalized `onDataLoad`');
             }
             else
             {
-                onDataLoad.dispatch();
-                onDataLoad.removeAll();
+				onWaveformBufferSet.dispatch();
+				onWaveformBufferSet.removeAll();
             }
     }
 

--- a/src/flixel/addons/display/waveform/FlxWaveform.hx
+++ b/src/flixel/addons/display/waveform/FlxWaveform.hx
@@ -403,16 +403,17 @@ class FlxWaveform extends FlxSprite
 
         _drawDataDirty = true;
 
-		if (onDataLoad == null)
-        {
-			onDataLoad = new FlxSignal();
-			FlxG.log.add('[FlxWaveform] Re-initalized `onDataLoad`');
-		}
-        else
-        {
-			onDataLoad.dispatch();
-			onDataLoad.removeAll();
-		}
+        if (waveformBuffer != null)
+            if (onDataLoad == null)
+            {
+                onDataLoad = new FlxSignal();
+                FlxG.log.add('[FlxWaveform] Re-initalized `onDataLoad`');
+            }
+            else
+            {
+                onDataLoad.dispatch();
+                onDataLoad.removeAll();
+            }
     }
 
     /**

--- a/src/flixel/addons/display/waveform/FlxWaveform.hx
+++ b/src/flixel/addons/display/waveform/FlxWaveform.hx
@@ -8,6 +8,7 @@ import flixel.addons.display.waveform.data.WaveformSegment;
 import flixel.sound.FlxSound;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
+import flixel.util.FlxSignal;
 import lime.media.AudioBuffer;
 import lime.utils.Float32Array;
 import openfl.geom.Rectangle;
@@ -361,6 +362,14 @@ class FlxWaveform extends FlxSprite
         loadDataFromFlxWaveformBuffer(FlxWaveformBuffer.fromLimeAudioBuffer(buffer));
     }
 
+	/**
+	 * Dispatches when data on loaded
+     * and removes all signals as soon as that happens
+	 * 
+	 * @since 2.2.0
+	 */
+	public var onDataLoad:FlxSignal = new FlxSignal();
+
    /**
      * Loads the audio buffer data neccessary for processing the 
      * waveform from a `FlxWaveformBuffer`.
@@ -393,6 +402,17 @@ class FlxWaveform extends FlxSprite
             waveformDuration = 5000;
 
         _drawDataDirty = true;
+
+		if (onDataLoad == null)
+        {
+			onDataLoad = new FlxSignal();
+			FlxG.log.add('[FlxWaveform] Re-initalized `onDataLoad`');
+		}
+        else
+        {
+			onDataLoad.dispatch();
+			onDataLoad.removeAll();
+		}
     }
 
     /**


### PR DESCRIPTION
## Desc

Adds an `onDataLoad` FlxSignal to ensure something happens on or to the waveform when it's done loading.

## Example

Only example I have right now is in Rhythm Walker 0.3 where I use the signal so I can put the FlxWaveform in a cache variable

<img width="768" height="290" alt="image" src="https://github.com/user-attachments/assets/02a77e80-8456-4e34-b426-ddc7ecb31a60" />
